### PR TITLE
KK-3235 checkers don't have to have the same type as makers

### DIFF
--- a/lib/four_eyes/concerns/controllers/actions_controller.rb
+++ b/lib/four_eyes/concerns/controllers/actions_controller.rb
@@ -41,7 +41,7 @@ module FourEyes
         # @params action - The action to be authorized
         # @params checker - The checker resource requesting to authorize
         def eligible_to_check(action, checker)
-          action.maker_id != checker.id
+          action.maker != checker
         end
 
         # Cancel an action that had been previously initiated


### PR DESCRIPTION
verifying that the checker is not the maker just by using the id could backfire if the maker and the checker have the same id but different types.